### PR TITLE
Mappings.AWSArch2AMI.us-east-1.HVM64EBS updated.

### DIFF
--- a/mappings.yml
+++ b/mappings.yml
@@ -17,4 +17,4 @@ Mappings:
 
   # Ubuntu 15.04
   AWSArch2AMI:
-    us-east-1     : { HVM64EBS: ami-899d5be2 }
+    us-east-1     : { HVM64EBS: ami-55986a3e }


### PR DESCRIPTION
Previous AMI resulted in CREATE_FAILED: AMI cannot be described

New AMI is:
us-east-1 vivid 15.04 DEVEL amd64 hvm:ebs-io1 20150616.1  ami-53986a38  hvm