### PR TITLE
EC2 LaunchConfiguration AssociatePublicIpAddress: true

### DIFF
--- a/buildkite-elastic.yml
+++ b/buildkite-elastic.yml
@@ -122,6 +122,7 @@ Resources:
   AgentLaunchConfiguration:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
+      AssociatePublicIpAddress: true
       SecurityGroups: [ $(SecurityGroup) ]
       KeyName : $(KeyName)
       IamInstanceProfile: $(IAMInstanceProfile)


### PR DESCRIPTION
Ensures each EC2 instance is allocated a public IP address.  VPC may default to
not allocating public IP address.