### PR TITLE
Docker uses default DNS, not Google's 8.8.8.8

### DIFF
--- a/packer/conf/docker.defaults
+++ b/packer/conf/docker.defaults
@@ -1,3 +1,3 @@
 
 # Use DOCKER_OPTS to modify the daemon startup options.
-DOCKER_OPTS="-G docker --dns 8.8.8.8 --dns 8.8.4.4"
+DOCKER_OPTS="-G docker"


### PR DESCRIPTION
For whatever reason, the EC2 instances I'm working with don't receive responses to DNS queries against `8.8.8.8` and `8.8.4.4` (possibly all external DNS), but they work fine with AWS internal DNS as configured by default in the EC2 instance.

Docker by default will pass this working DNS into the containers, which is preferable to using an external resolver regardless of whether I can get `8.8.8.8` etc working.