### PR TITLE
buildkite/agent not lox24/buildkite-agent; PR merged.

### DIFF
--- a/buildkite-elastic.yml
+++ b/buildkite-elastic.yml
@@ -194,7 +194,7 @@ Resources:
             "/home/ubuntu/docker-compose.yml":
               content: |
                 buildkite:
-                  image: lox24/buildkite-agent:dind-1.6
+                  image: buildkite/agent:dind-1.6
                   privileged: true
                   environment:
                     - BUILDKITE_AGENT_TOKEN=$(BuildkiteAgentToken)


### PR DESCRIPTION
Switching from @lox's fork back to the official [buildkite/agent](https://hub.docker.com/r/buildkite/agent/) since https://github.com/buildkite/docker-buildkite-agent/pull/8 was merged.